### PR TITLE
Copy dependencies into a single directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,16 @@ To manually enable the use of ``ansys-tools-protoc-helper`` in your project, the
 
         where ``<your.package.name>`` is the _importable_ name of your package. In other words, ``import <your.package.name>`` should work after installing the package.
 
+        By default, the the ``.proto`` files will be copied to ``your/package/name``. If a different location should be used, append a semicolon to the entry point name, followed by the dot-separated target location:
+
+        .. code:: python
+
+            entry_points={
+                "ansys.tools.protoc_helper.proto_provider": {
+                    "<your.package.name>:<target.location>=<your.package.name>"
+                },
+            },
+
 For a complete example, see the ``test/test_data/testpkg-greeter-protos`` package.
 
 gRPC version strategy

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ To manually enable the use of ``ansys-tools-protoc-helper`` in your project, the
 
         where ``<your.package.name>`` is the _importable_ name of your package. In other words, ``import <your.package.name>`` should work after installing the package.
 
-        By default, the the ``.proto`` files will be copied to ``your/package/name``. If a different location should be used, append a semicolon to the entry point name, followed by the dot-separated target location:
+        By default, the ``.proto`` files will be copied to ``your/package/name``. If a different location should be used, append a semicolon to the entry point name, followed by the dot-separated target location:
 
         .. code:: python
 

--- a/ansys/tools/protoc_helper/__init__.py
+++ b/ansys/tools/protoc_helper/__init__.py
@@ -2,5 +2,5 @@
 from ._compile_protos import *
 from ._distutils_overrides import *
 
-__version__ = "0.0.0"
+__version__ = "0.1.dev0"
 __all__ = _compile_protos.__all__ + _distutils_overrides.__all__  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ doc = [
 [project.urls]
 Source = "https://github.com/ansys/ansys-tools-protoc-helper"
 
+[project.entry-points."ansys.tools.protoc_helper.proto_provider"]
+"google.base_protos:" = "grpc_tools._proto"
+
 [tool.flit.module]
 name = "ansys.tools.protoc_helper"
 

--- a/test/test_data/testpkg-greeter-protos/testpkg/api/greeter/v0/greeter3.proto
+++ b/test/test_data/testpkg-greeter-protos/testpkg/api/greeter/v0/greeter3.proto
@@ -2,8 +2,9 @@ syntax = "proto3";
 
 package testpkg.api.greeter.v0.greeter3;
 
+import "google/protobuf/empty.proto";
 import "testpkg/api/hello/hello.proto";
 
 service Greeter3 {
-    rpc SayHello(testpkg.api.hello.hello.Hello) returns (testpkg.api.hello.hello.Hello);
+    rpc SayHello(testpkg.api.hello.hello.Hello) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
Copies dependencies into a single directory instead of one directory
per entry point. This avoids 'protoc' erroring out when a .proto
exists in multiple entry points. When the two files are not
identical, a warning is emitted.

Changes the semantics of the entry point name: Previously, it was
arbitrary. Now, the location to which the .protos are copied can
be (optionally) specified after a semicolon.

Always include the base google .proto files.