### PR TITLE
Add upper bound for Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   hooks:
   - id: reorder-python-imports
     args: ["--py37-plus"]
-- repo: https://gitlab.com/PyCQA/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.10.0
   hooks:
   - id: black
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+  rev: v3.9.0
   hooks:
   - id: reorder-python-imports
     args: ["--py37-plus"]
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
   - id: flake8
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.1.0
+  rev: v2.2.2
   hooks:
   - id: codespell
 - repo: https://github.com/pycqa/pydocstyle

--- a/ansys/tools/protoc_helper/_compile_protos.py
+++ b/ansys/tools/protoc_helper/_compile_protos.py
@@ -66,7 +66,7 @@ def compile_proto_files(target_package: str) -> None:
 def _recursive_copy(src_traversable: Traversable, dest_path: pathlib.Path) -> None:
     """Copy ``.proto`` files contained in a ``Traversable`` to a given location."""
     if src_traversable.is_dir():
-        for content in src_traversable.iterdir():  # type: ignore
+        for content in src_traversable.iterdir():
             _recursive_copy(content, dest_path / content.name)
     else:
         assert src_traversable.is_file()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.rst"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
-requires-python = ">=3.7"
+requires-python = ">=3.7,<3.11"
 dependencies = [
     "setuptools>=42.0",
     "grpcio-tools==1.17.0",


### PR DESCRIPTION
Temporary improvement for #29.

Includes the needed fixes for the pre-commit hooks:
- Consume flake8 from GitHub instead of GitLab
- Update hook versions (fixes black `_unicodefun` issue)
- Remove unneeded `type: ignore`