### PR TITLE
Update grpc dependency to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - "*"
     branches:
       - main
+  workflow_dispatch:
+    inputs:
 
 jobs:
   pre-commit:

--- a/README.rst
+++ b/README.rst
@@ -104,11 +104,11 @@ For example, if ``ansys-tools-protoc-helper`` pins
 .. code::
 
     dependencies = [
-        "grpcio-tools==1.17.0",
+        "grpcio-tools==1.20.0",
         "protobuf==3.19.3",
     ]
 
-your own dependencies could be ``grpcio-tools~=1.17``, ``protobuf~=3.19`` (using the ``~=`` `compatible version operator <https://www.python.org/dev/peps/pep-0440/#compatible-release>`_).
+your own dependencies could be ``grpcio-tools~=1.20``, ``protobuf~=3.19`` (using the ``~=`` `compatible version operator <https://www.python.org/dev/peps/pep-0440/#compatible-release>`_).
 
 The versions pinned by ``ansys-tools-protoc-helper`` are chosen as follows:
 

--- a/ansys/tools/protoc_helper/__init__.py
+++ b/ansys/tools/protoc_helper/__init__.py
@@ -2,5 +2,5 @@
 from ._compile_protos import *
 from ._distutils_overrides import *
 
-__version__ = "0.1.2"
+__version__ = "0.2.dev0"
 __all__ = _compile_protos.__all__ + _distutils_overrides.__all__  # type: ignore

--- a/ansys/tools/protoc_helper/__init__.py
+++ b/ansys/tools/protoc_helper/__init__.py
@@ -2,5 +2,5 @@
 from ._compile_protos import *
 from ._distutils_overrides import *
 
-__version__ = "0.1.dev0"
+__version__ = "0.1.2"
 __all__ = _compile_protos.__all__ + _distutils_overrides.__all__  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "description"]
 requires-python = ">=3.7,<3.11"
 dependencies = [
     "setuptools>=42.0",
-    "grpcio-tools==1.17.0",
+    "grpcio-tools==1.20.0",
     "protobuf==3.19.3",
     "mypy-protobuf==3.1.0",
     "importlib-resources>=1.3"


### PR DESCRIPTION
The `1.17` version of `grpcio-tools` could no longer be built because it depends on `protobuf`
with a `>=`, but is incompatible with the `4.x` release.

Update the version to `0.1.2`.

Add a `workflow_dispatch` to CI, to allow manually triggering the actions.